### PR TITLE
feat: add "bare metal" postgres db backup with cron

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -21,6 +21,7 @@
   become: yes
   roles:
     - geerlingguy.postgresql
+    - pg_backup_cron
 
 - hosts: redis
   become: yes

--- a/roles/pg_backup_cron/defaults/main.yml
+++ b/roles/pg_backup_cron/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 pg_backup_cron_database: "{{ postgresql_databases[0].name  | default('postgres') }}"
+pg_backup_cron_ping_url:

--- a/roles/pg_backup_cron/tasks/main.yml
+++ b/roles/pg_backup_cron/tasks/main.yml
@@ -13,26 +13,21 @@
     - /var/lib/postgresql/bin/
     - /var/lib/postgresql/backups/
 
-- name: "upload the backup script"
+- name: "upload script"
   template:
-    src: backup.sh.j2
-    dest: /var/lib/postgresql/bin/backup.sh
+    src: "{{ item }}.j2"
+    dest: "/var/lib/postgresql/bin/{{ item }}"
     owner: postgres
     group: postgres
     mode: 0500
-
-- name: "upload the backup post dump success script"
-  template:
-    src: backup_post_dump_success.sh.j2
-    dest: /var/lib/postgresql/bin/backup_post_dump_success.sh
-    owner: postgres
-    group: postgres
-    mode: 0500
+  with_items:
+    - backup.sh
+    - backup_post_dump_success.sh
 
 - name: "setup cronjob as postgres user"
   ansible.builtin.cron:
     name: "run backup script"
-    hour: "3"
     minute: "0"
+    hour: "3"
     user: postgres
     job: "/var/lib/postgresql/bin/backup.sh"

--- a/roles/pg_backup_cron/tasks/main.yml
+++ b/roles/pg_backup_cron/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: "call `pg_dump --version`"
+  ansible.builtin.command: "pg_dump --version"
+
+- name: "create bin/ directory"
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: 0700
+  with_items:
+    - /var/lib/postgresql/bin/
+    - /var/lib/postgresql/backups/
+
+- name: "upload the backup script"
+  template:
+    src: backup.sh.j2
+    dest: /var/lib/postgresql/bin/backup.sh
+    owner: postgres
+    group: postgres
+    mode: 0500
+
+- name: "upload the backup post dump success script"
+  template:
+    src: backup_post_dump_success.sh.j2
+    dest: /var/lib/postgresql/bin/backup_post_dump_success.sh
+    owner: postgres
+    group: postgres
+    mode: 0500
+
+- name: "setup cronjob as postgres user"
+  ansible.builtin.cron:
+    name: "run backup script"
+    hour: "3"
+    minute: "0"
+    user: postgres
+    job: "/var/lib/postgresql/bin/backup.sh"

--- a/roles/pg_backup_cron/templates/backup.sh.j2
+++ b/roles/pg_backup_cron/templates/backup.sh.j2
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+set -euo pipefail
+
+mkdir -p ~/backups
+chmod 700 ~/backups
+
+# setup variables
+db_name="{{ pg_backup_cron_database }}"
+file_name="$(date '+%Y-%m-%d_%H%M%S')_$db_name.sql.gz"
+file="$HOME/backups/$file_name"
+
+pg_dump -U postgres "$db_name" | gzip > "$file"
+
+"$HOME/bin/backup_post_dump_success.sh" "$file"

--- a/roles/pg_backup_cron/templates/backup.sh.j2
+++ b/roles/pg_backup_cron/templates/backup.sh.j2
@@ -8,7 +8,7 @@ mkdir -p ~/backups
 chmod 700 ~/backups
 
 # setup variables
-db_name="{{ pg_backup_cron_database }}"
+db_name="{{ pg_backup_cron_database | mandatory }}"
 file_name="$(date '+%Y-%m-%d_%H%M%S')_$db_name.sql.gz"
 file="$HOME/backups/$file_name"
 

--- a/roles/pg_backup_cron/templates/backup_post_dump_success.sh.j2
+++ b/roles/pg_backup_cron/templates/backup_post_dump_success.sh.j2
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+
+set -euo pipefail
+
+##
+# This script is called after a succesful pg_dump of the database.
+#
+# It's called with the file as first argument:
+
+# file="$1"
+# file_name=$(basename "$file")
+
+# Setup some further actions below. E.g.:
+#
+# - encrypt the file with gpg
+# echo $GPG_PASSPHRASE | gpg --no-tty --cipher-algo aes256 --passphrase-fd 0 -ca "$file"
+#
+# - upload via scp:
+# scp "$file" backup-server:~/backups
+#
+# - ugh, do you really want to send this via mail? encrypt it first!
+# mail -s "$file_name" -a "$file.asc" someone@yourorg
+#
+# - remove file:
+# rm "$file"
+#
+# - send a healthcheck ping
+# curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/...

--- a/roles/pg_backup_cron/templates/backup_post_dump_success.sh.j2
+++ b/roles/pg_backup_cron/templates/backup_post_dump_success.sh.j2
@@ -5,13 +5,14 @@
 set -euo pipefail
 
 ##
-# This script is called after a succesful pg_dump of the database.
+# This script is called after succesful dump of the database.
 #
 # It's called with the file as first argument:
-
+#
 # file="$1"
 # file_name=$(basename "$file")
 
+{#
 # Setup some further actions below. E.g.:
 #
 # - encrypt the file with gpg
@@ -27,4 +28,8 @@ set -euo pipefail
 # rm "$file"
 #
 # - send a healthcheck ping
-# curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/...
+#}
+
+{% if pg_backup_cron_ping_url %}
+curl -fsS -m 10 --retry 5 -o /dev/null {{ pg_backup_cron_ping_url }}
+{% endif %}

--- a/roles/pg_backup_cron/vars/main.yml
+++ b/roles/pg_backup_cron/vars/main.yml
@@ -1,0 +1,2 @@
+---
+pg_backup_cron_database: "{{ postgresql_databases[0].name  | default('postgres') }}"


### PR DESCRIPTION
This is a starting point.
The role should be made further configurable via variables.

- [x] configurable hc-ping url
- [ ] support multiple databases (when more than one specified)
- [ ] use pg_dump's "custom format" 